### PR TITLE
[merge] matlab: envs for 2019b, 2024a, 2023b and others

### DIFF
--- a/conf/03-site/linux/include.yaml
+++ b/conf/03-site/linux/include.yaml
@@ -3,6 +3,7 @@ include:
   - path: package-policies/core.yaml
   - path: package-policies/build.yaml
   - path: package-policies/extra.yaml
+  - path: package-policies/gui.yaml
   - path: package-policies/compilers/commons.yaml
   - path: package-policies/compilers/aocc.yaml
   - path: package-policies/compilers/gcc.yaml
@@ -10,8 +11,7 @@ include:
   - path: package-policies/compilers/nvhpc.yaml
   - path: package-policies/compilers/oneapi.yaml
   - path: package-policies/externals/gui-external.yaml
-  - path: package-policies/gui.yaml
   - path: package-policies/externals/mpi-external.yaml
-  - path: package-keys/matlab.yaml
   - path: package-policies/apps/boost.yaml
   - path: package-policies/apps/hdf5-netcdf.yaml
+  - path: package-keys/matlab.yaml

--- a/conf/03-site/linux/include.yaml
+++ b/conf/03-site/linux/include.yaml
@@ -12,6 +12,6 @@ include:
   - path: package-policies/externals/gui-external.yaml
   - path: package-policies/gui.yaml
   - path: package-policies/externals/mpi-external.yaml
-  - path: package-policies/mpi-roce-slurm.yaml
-  - path: package-policies/apps/boost.yaml
   - path: package-keys/matlab.yaml
+  - path: package-policies/apps/boost.yaml
+  - path: package-policies/apps/hdf5-netcdf.yaml

--- a/conf/03-site/linux/include.yaml
+++ b/conf/03-site/linux/include.yaml
@@ -13,5 +13,4 @@ include:
   - path: package-policies/externals/gui-external.yaml
   - path: package-policies/externals/mpi-external.yaml
   - path: package-policies/apps/boost.yaml
-  - path: package-policies/apps/hdf5-netcdf.yaml
   - path: package-keys/matlab.yaml


### PR DESCRIPTION
Depends on #23 #24 