### PR TITLE
export individual build-tools into modules

### DIFF
--- a/conf/03-site/linux/include.yaml
+++ b/conf/03-site/linux/include.yaml
@@ -16,4 +16,5 @@ include:
   - path: package-policies/apps/boost.yaml
   - path: package-policies/apps/cuda.yaml
   - path: package-policies/apps/hdf5-netcdf.yaml
+  - path: package-policies/apps/r.yaml
   - path: package-keys/matlab.yaml

--- a/conf/03-site/linux/package-policies/apps/r.yaml
+++ b/conf/03-site/linux/package-policies/apps/r.yaml
@@ -1,0 +1,5 @@
+packages:
+  r:
+    require:
+      - +X
+      - +rmath

--- a/envs/03-site/5000-build-tools/spack.yaml
+++ b/envs/03-site/5000-build-tools/spack.yaml
@@ -1,0 +1,22 @@
+spack:
+  concretizer:
+    unify: false
+  packages:
+    all:
+      require:
+        - "target=x86_64_v4 %gcc@11.5.0.spack"
+  specs:
+    - ant
+    - autotools
+    - bazel
+    - cmake
+    - doxygen
+    - fpm
+    - gmake
+    - gradle
+    - maven
+    - meson
+    - ninja
+    - scons
+    - texlive
+  view: false

--- a/envs/03-site/5000-utils/spack.yaml
+++ b/envs/03-site/5000-utils/spack.yaml
@@ -7,7 +7,6 @@ spack:
         - "target=x86_64_v4 %gcc@11.5.0.spack"
   specs:
     - bash
-    - cmake
     - cvs
     - emacs +json
     - git
@@ -16,6 +15,5 @@ spack:
     - mercurial
     - subversion
     - tcl
-    - texlive
     - zsh
   view: false

--- a/envs/03-site/5001-r/spack.yaml
+++ b/envs/03-site/5001-r/spack.yaml
@@ -8,9 +8,11 @@ spack:
       lmod:
         r:
           template: modules/r-modulefile.lua
+  packages:
+    all:
+      require:
+        - "target=x86_64_v4 %gcc@11.5.0.spack"
   specs:
-    - matrix:
-        - - r@4.4.1 +X+rmath
-          - rstudio@2024.09.1 ^r@4.4.1 +X+rmath
-        - - platform=linux target=x86_64_v4 %gcc@11.5.0.spack
+    - r@4.4.1
+    - rstudio@2024.09.1
   view: false


### PR DESCRIPTION
Many complaint cannot find cmake which is already available in build-tools collection.

This explicitly export those build tools modules.