### PR TITLE
lmod defaults to name/version-hash

### DIFF
--- a/conf/03-site/modules.yaml
+++ b/conf/03-site/modules.yaml
@@ -14,15 +14,18 @@ modules:
         - compiler
       intel-oneapi-mpi:
         environment:
-          'set:':
+          "set:":
             I_MPI_FABRICS: "shm:ofi"
       projections:
-        all: "{name}/{version}-{target.name}"
-        aocc: "{name}/{version}"
-        gcc: "{name}/{version}"
-        intel-oneapi-compilers: "{name}/{version}"
-        intel-oneapi-compilers-classic: "{name}/{version}"
-        intel-oneapi-mpi: "{name}/{version}"
+        all: "{name}/{version}"
+        hdf5: "{name}/{version}-{target.name}"
+        intel-oneapi-mpi: "{name}/{version}-{target.name}"
+        mpich: "{name}/{version}-{target.name}"
+        netcdf-c: "{name}/{version}-{target.name}"
+        netcdf-fortran: "{name}/{version}-{target.name}"
+        openmpi: "{name}/{version}-{target.name}"
+        parallel-netcdf: "{name}/{version}-{target.name}"
+        parallelio: "{name}/{version}-{target.name}"
   prefix_inspections:
     ./:
       - CMAKE_PREFIX_PATH


### PR DESCRIPTION
majority of package offered at core does not care about performance related to microarchitecture that much.

the default is changed for easier maintenance
- package by default is exported as `<name>/<version>-<hash>`, expecting it to be a general version
- package which are performance critical uses `<name>/<version>-<arch>-<hash>`, these packages must be listed in config